### PR TITLE
Remove WebDriverManager dependency and update to Selenium 4.13

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,3 +3,4 @@ increment: Inherit
 branches: {}
 ignore:
   sha: []
+  


### PR DESCRIPTION
- As now built-in Selenium Manager allows to download driver, we don't need to maintain webDriverManager dependency.

- updated core library to use Selenium 4.13 (latest supported for Java 8)
- removed jackson-databind dependency
- update testng to 7.5.1 (latest supported for Java 8)
- added commons-lang dependency
- add workflow to automatically deploy to maven central after PR merge