### PR TITLE
Remove WebDriverManager dependency and update to Selenium 4.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
@@ -224,7 +224,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- As now built-in Selenium Manager allows to download driver, we don't need to maintain webDriverManager dependency.
- updated core library to use Selenium 4.13.0 (latest compatible with Java 8)
- removed jackson-databind dependency
- update testng to 7.5.1 (latest compatible with Java 8)
- added commons-lang dependency
- add workflow to automatically deploy to maven central after PR merge