### PR TITLE
Update dependencies and restore jackson databind dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.github.aquality-automation</groupId>
             <artifactId>aquality-selenium-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -90,9 +90,15 @@
             <version>3.13.0</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.10</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
aquality.selenium.core dependency was updated to 3.1.1 Updates in the core library:
- log4j to 2.22.1
- testng to 7.5.1
- jackson-databind to 2.16.1
- guice to 6.0.0, guava exclusion removed

Also scope for slf4j-simple was set to test.