### PR TITLE
Support Opera browser with chromedriver

### DIFF
--- a/src/main/java/aquality/selenium/browser/LocalBrowserFactory.java
+++ b/src/main/java/aquality/selenium/browser/LocalBrowserFactory.java
@@ -5,6 +5,7 @@ import aquality.selenium.configuration.driversettings.IDriverSettings;
 import aquality.selenium.core.localization.ILocalizedLogger;
 import aquality.selenium.core.utilities.IActionRetrier;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.edge.EdgeOptions;
@@ -32,8 +33,12 @@ public class LocalBrowserFactory extends BrowserFactory {
         IDriverSettings driverSettings = browserProfile.getDriverSettings();
         switch (browserName) {
             case CHROME:
-            case YANDEX:
                 driver = new ChromeDriver((ChromeOptions) driverSettings.getDriverOptions());
+                break;
+            case YANDEX:
+            case OPERA:
+                driver = new ChromeDriver(new ChromeDriverService.Builder().withBuildCheckDisabled(true).build(),
+                        (ChromeOptions) driverSettings.getDriverOptions());
                 break;
             case FIREFOX:
                 driver = new FirefoxDriver((FirefoxOptions) driverSettings.getDriverOptions());

--- a/src/main/java/aquality/selenium/configuration/BrowserProfile.java
+++ b/src/main/java/aquality/selenium/configuration/BrowserProfile.java
@@ -52,6 +52,9 @@ public class BrowserProfile implements IBrowserProfile {
             case SAFARI:
                 driverSettings = new SafariSettings(settingsFile);
                 break;
+            case OPERA:
+                driverSettings = new OperaSettings(settingsFile);
+                break;
             case YANDEX:
                 driverSettings = new YandexSettings(settingsFile);
                 break;

--- a/src/main/java/aquality/selenium/configuration/driversettings/OperaSettings.java
+++ b/src/main/java/aquality/selenium/configuration/driversettings/OperaSettings.java
@@ -1,0 +1,26 @@
+package aquality.selenium.configuration.driversettings;
+
+import aquality.selenium.browser.BrowserName;
+import aquality.selenium.core.utilities.ISettingsFile;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.AbstractDriverOptions;
+
+public class OperaSettings extends ChromeSettings {
+    private static final String DEFAULT_BINARY_LOCATION = "%USERPROFILE%\\AppData\\Local\\Programs\\Opera\\launcher.exe";
+    public OperaSettings(ISettingsFile settingsFile) {
+        super(settingsFile);
+    }
+
+    @Override
+    public AbstractDriverOptions<?> getDriverOptions() {
+        ChromeOptions options = (ChromeOptions) super.getDriverOptions();
+        options.setExperimentalOption("w3c", true);
+        options.setBinary(getBinaryLocation(DEFAULT_BINARY_LOCATION));
+        return options;
+    }
+
+    @Override
+    public BrowserName getBrowserName() {
+        return BrowserName.OPERA;
+    }
+}

--- a/src/main/resources/settings.json
+++ b/src/main/resources/settings.json
@@ -66,6 +66,21 @@
     "safari": {
       "downloadDir": "/Users/username/Downloads"
     },
+    "opera": {
+      "binaryLocation": "%USERPROFILE%\\AppData\\Local\\Programs\\Opera\\launcher.exe",
+      "capabilities": {
+        "unhandledPromptBehavior": "ignore"
+      },
+      "options": {
+        "intl.accept_languages": "en",
+        "safebrowsing.enabled": "true",
+        "profile.default_content_settings.popups": "0",
+        "disable-popup-blocking": "true",
+        "download.prompt_for_download": "false",
+        "download.default_directory": "./downloads"
+      },
+      "startArguments": [ "--remote-debugging-port=9222", "--no-sandbox", "--disable-dev-shm-usage" ]
+    },
     "yandex": {
       "binaryLocation": "%USERPROFILE%\\AppData\\Local\\Yandex\\YandexBrowser\\Application\\browser.exe",
       "capabilities": {

--- a/src/test/resources/settings.json
+++ b/src/test/resources/settings.json
@@ -65,6 +65,21 @@
     "safari": {
       "downloadDir": "/Users/username/Downloads"
     },
+    "opera": {
+      "binaryLocation": "%USERPROFILE%\\AppData\\Local\\Programs\\Opera\\launcher.exe",
+      "capabilities": {
+        "unhandledPromptBehavior": "ignore"
+      },
+      "options": {
+        "intl.accept_languages": "en",
+        "safebrowsing.enabled": "true",
+        "profile.default_content_settings.popups": "0",
+        "disable-popup-blocking": "true",
+        "download.prompt_for_download": "false",
+        "download.default_directory": "./downloads"
+      },
+      "startArguments": [ "--remote-debugging-port=9222", "--no-sandbox", "--disable-dev-shm-usage" ]
+    },
     "yandex": {
       "binaryLocation": "%USERPROFILE%\\AppData\\Local\\Yandex\\YandexBrowser\\Application\\browser.exe",
       "capabilities": {


### PR DESCRIPTION
Support Opera and Yandex browsers
- Add section to settings.json for Opera browser
- Add specific OperaSettings with w3c workaround and binary location
- Update LocalBrowserFactory to separate Opera and Yandex cases from Chrome. For them, use ChromeDriverService with disabled build check